### PR TITLE
Use hyphenated GUID format in template generation

### DIFF
--- a/Flow.Launcher.Plugin.Template/.template.config/template.json
+++ b/Flow.Launcher.Plugin.Template/.template.config/template.json
@@ -17,7 +17,7 @@
         "generator": "guid",
         "replaces":"PluginId",
         "parameters": {
-            "defaultFormat":"N"
+            "defaultFormat":"D"
         }
       },
       "pluginAuthor": {


### PR DESCRIPTION
Changes pluginId generator defaultFormat from "N" to "D"

Formats explained:
- https://github.com/dotnet/templating/wiki/Available-Symbols-Generators#guid
- https://learn.microsoft.com/en-us/dotnet/api/system.guid.tostring?view=net-10.0&redirectedfrom=MSDN#System_Guid_ToString_System_String_

Some plugins use the hyphen, others dont.
I've been previously told (https://github.com/Flow-Launcher/Flow.Launcher.PluginsManifest/pull/607#issuecomment-3881286731) that the hyphenated version is required.
If this is true then the template should be updated to match this requirement.